### PR TITLE
Hash the slack id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,11 @@ gem "jbuilder", "~> 2.7"
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# Authorization
 gem "omniauth"
 gem "omniauth-slack"
 
+# Secrets
 gem "figaro"
 
 # Use Active Storage variant
@@ -32,6 +34,9 @@ gem "figaro"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
+
+# Utilities
+gem "awesome_print"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
+    awesome_print (1.8.0)
     bindex (0.8.1)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
@@ -295,6 +296,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.34)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The Turing School of Software Design has a mission to:
 
 We believe that a small part of achieving that mission involves sharing salary data within the Turing community. While salary information has been available in a variety of forms for years, this project is an attempt to systematize the process.
 
+## User Anonymity
+Many people are uncomfortable sharing their salaries, but feel less averse to providing that information anonymously. For that reason, we take the following steps to ensure user anonymity.
+1. Users authenticate using Turing Slack, which ensures that only members of the Turing community can use this application.
+2. The only data returned to this app through the slack authentication process we touch is the user's `slack_id`. We do not look at any other data returned via the oauth request flow.
+3. Rather than saving the slack_id to our database, and thus undermining the goal of preserving anonymity, we hash the slack_id using a one way, deterministic hashing algorithm. It is not possible to get back to the user's `slack_id` from the hashed version in our database. For more information we encourage you to review this [pr](https://github.com/jesse-spevack/salaries/pull/37).
+
 ## Project Road Map
 We are currently working to produce an MVP defined [here](https://github.com/jesse-spevack/salaries/projects/1). The key features of the MVP include:
 - Turing slack login

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   skip_before_action :require_login, only: [:create]
 
   def create
-    @user = User.find_or_create_by(slack_id: auth_hash.info.user_id)
+    @user = authentication_service.find_or_create_user
     session[:user_id] = @user.id
     redirect_to profile_path
   end
@@ -17,7 +17,7 @@ class SessionsController < ApplicationController
 
   private
 
-  def auth_hash
-    request.env["omniauth.auth"]
+  def authentication_service
+    AuthenticationService.new(request.env["omniauth.auth"])
   end
 end

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -1,0 +1,19 @@
+# We do not want to store the actual slack id in order to
+# keep users anonymous. Instead we use SHA256 to create a hashed
+# version of the id and store that in the DB. SHA256
+# is a one way, deterministic hashing algorithm. It is impossible to
+# go from hashed_slack_id back to the original id. It is only possible
+# to go from slack_id to hashed_slack_id.
+class AuthenticationService
+  # @param auth_hash [OmniAuth::AuthHash] the omniauth hash returned in an omniauth request
+  # @return [AuthenticationService] an instance of the authentication service
+  def initialize(auth_hash)
+    slack_id = auth_hash.info.user_id
+    @hashed_slack_id = Digest::SHA256.hexdigest(slack_id)
+  end
+
+  # @return [User] an instance of a user
+  def find_or_create_user
+    User.find_or_create_by(slack_id: @hashed_slack_id)
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :user do
-    slack_id { "12345ABCDEF" }
+    # We never store the actual slack id in our database, only a hashed version.
+    # It is impossible to back into the slack id given the hashed id.
+    slack_id { Digest::SHA256.hexdigest("12345ABCDEF") }
   end
 end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,14 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Logging in with slack", type: :feature do
-  let(:user) { build(:user) }
-  let(:hashed_id) { Digest::SHA256.hexdigest(user.slack_id) }
+  let(:slack_id) { "raw_slack_id_12345" }
+  let(:hashed_id) { Digest::SHA256.hexdigest(slack_id) }
+  let(:user) { create(:user, slack_id: hashed_id) }
 
   before do
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:slack] = OmniAuth::AuthHash.new(
       info: {
-        user_id: user.slack_id
+        user_id: slack_id
       }
     )
   end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Logging in with slack", type: :feature do
   let(:user) { build(:user) }
+  let(:hashed_id) { Digest::SHA256.hexdigest(user.slack_id) }
 
   before do
     OmniAuth.config.test_mode = true
@@ -15,7 +16,7 @@ RSpec.describe "Logging in with slack", type: :feature do
   scenario "shows logout link" do
     visit root_path
     click_link
-    expect(page).to have_content(user.slack_id)
+    expect(page).to have_content(hashed_id)
     expect(page).to have_link("Logout")
     expect(current_path).to eq profile_path
   end

--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe AuthenticationService do
+  subject { described_class.new(auth_hash) }
+
+  let(:slack_id) { "raw_slack_id_123" }
+  let(:hashed_slack_id) { Digest::SHA256.hexdigest(slack_id) }
+  let(:auth_hash) { instance_double "Omniauth Hash" }
+  let(:auth_info_hash) { instance_double "Omniauth Hash" }
+
+  before do
+    # Mock omniauth hash behavior
+    # slack_id = request.env["omniauth.auth"].info.user_id
+    # "my_slack_id_12345"
+    allow(auth_hash).to receive(:info).and_return(auth_info_hash)
+    allow(auth_info_hash).to receive(:user_id).and_return(slack_id)
+  end
+
+  describe "#find_or_create_user" do
+    context "when user exists" do
+      let!(:user) { create(:user, slack_id: hashed_slack_id) }
+
+      it "returns user" do
+        expect(subject.find_or_create_user).to eq user
+      end
+    end
+
+    context "when user does not exist" do
+      it "creates user" do
+        expect { subject.find_or_create_user }.to change { User.count }.from(0).to(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#  Issue Link
[Encrypt Slack IDs for privacy #34](https://github.com/jesse-spevack/salaries/issues/34)

# Background

Users who report their salary with this application expect their anonymity to be maintained. At the same time, we only want members of the Turing community to be able to use this application. So the problem at issue here is how do we (1) authenticate that a user is part of Turing and also (2) not store any personally identifiable information that they themselves do not explicitly report?

The answer I've landed on here is to store a hashed version of the user's Turing Slack Id.

Using the Turing Slack Id ensures that the user is part of the turing community (problem 1).

Hashing the Slack Id and storing that in our database allows us to preserve the user's anonymity more completely (problem 2).

## Hashing

We use [SHA256](https://en.wikipedia.org/wiki/SHA-2) as our hashing algorithm because it is deterministic and one way.

```
slack_id -> SHA256 HASHING -> hashed_slack_id
```

Passing in the same slack id will always result in the same hashed_slack_id.
The hashing process is one way, which means it is impossible to go from hashed_slack_id back to slack_id.

```
hashed_slack_id -> SHA256 HASHING -> hashed_hashed_slack_id, not the original slack_id
```

