### PR TITLE
fix

### DIFF
--- a/spec/models/salary_spec.rb
+++ b/spec/models/salary_spec.rb
@@ -69,4 +69,26 @@ RSpec.describe Salary, type: :model do
       end
     end
   end
+
+  describe "location_attributes=" do
+    subject(:salary) { create(:salary, location: location) }
+
+    let!(:location) { create(:location) }
+
+    context "when one or more attribute is blank" do
+      let(:attributes) { {"place_id" => ""} }
+
+      it "sets location association to nil" do
+        expect { salary.location_attributes = attributes }.to change { salary.location }.from(kind_of(Location)).to(nil)
+      end
+    end
+
+    context "when all attributes are present" do
+      let(:attributes) { {"place_id" => "123", "name" => "my place"} }
+
+      it "sets location association to nil" do
+        expect { salary.location_attributes = attributes }.to change { Location.count }.from(1).to(2)
+      end
+    end
+  end
 end

--- a/spec/system/edit_salaries_spec.rb
+++ b/spec/system/edit_salaries_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Editing salaries", type: :system do
   before { driven_by(:selenium_chrome_headless) }
 
-  describe "creating new salary" do
+  describe "Editing salary" do
     let(:amount) { 80_000 }
     let(:remote_xpath) { "/html/body/div[2]/form/div[1]/div[3]/div[1]/div/button" }
 
@@ -34,6 +34,22 @@ RSpec.describe "Editing salaries", type: :system do
       location_field = find("#salary_location_attributes_name")
 
       expect(location_field.value).to eq ""
+    end
+
+    scenario "editing remote salary" do
+      user = mock_auth_hash
+      salary = create(:salary, :remote, user: user)
+      new_amount = salary.amount + 900
+
+      visit root_path
+      click_link "slack-login"
+
+      click_link "Edit"
+      fill_in("Amount", with: new_amount)
+      click_on "Save"
+
+      expect(current_path).to eq profile_path
+      expect(salary.reload.amount).to eq new_amount
     end
   end
 end


### PR DESCRIPTION
This PR is to fix a bug where a user:
- Edits a salary w/ remote = true
- Makes no changes in the salary form
- clicks save

The bug led a user to see an error message that the city can't be blank, even though remote is set to true.
![failures_r_spec_example_groups_editing_salaries_creating_new_salary_editing_remote_salary_56](https://user-images.githubusercontent.com/15135934/107902252-228a3500-6f03-11eb-9945-e9bb864117d7.png)

For some reason, the reject_if argument is not working the way I thought it would. I adopted a solution I found in this post: 

https://dev.to/katkelly/why-yes-i-ll-accept-those-nested-attributes-18f7

We overwrite the `location_attributes=` method to either find / create a location for a salary, when given complete params. Or, we set the salary location to nil.