### PR TITLE
Add some space between label and toggle on mobile screens

### DIFF
--- a/app/components/toggle_switch_component.html.erb
+++ b/app/components/toggle_switch_component.html.erb
@@ -13,7 +13,7 @@
   },
   class: "sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5"
 ) do %>
-  <%= content_tag(:span, class: "flex-grow flex flex-col", id: "toggleLabel") do %>
+  <%= content_tag(:span, class: "flex-grow flex flex-col pb-2 sm:pb-0", id: "toggleLabel") do %>
     <%= content_tag(:span, @attribute.to_s.titleize, class: "block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2") %>
   <% end %>
 


### PR DESCRIPTION
Before
![Screen Shot 2021-02-14 at 8 35 31 PM](https://user-images.githubusercontent.com/15135934/107902761-9d078480-6f04-11eb-981a-7cd1a94f9ffd.png)

After
![Screen Shot 2021-02-14 at 8 36 48 PM](https://user-images.githubusercontent.com/15135934/107902771-a09b0b80-6f04-11eb-9ea2-3c7e21378221.png)
