### PR TITLE
Add salary reporting service

### DIFF
--- a/app/services/salary_reporting_service.rb
+++ b/app/services/salary_reporting_service.rb
@@ -1,0 +1,46 @@
+# Responsible for database reporting
+class SalaryReportingService
+  def current_salary_by_graduation_year
+    sql = <<-SQL
+      SELECT
+        profiles.graduation_year AS graduation_year,
+        COUNT(salaries.id) AS submission_count,
+        CAST(AVG(salaries.amount) AS INTEGER) AS average_salary,
+        MIN(salaries.amount) AS minimum_salary,
+        MAX(salaries.amount) AS maximum_salary
+      FROM
+        salaries
+        JOIN users ON salaries.user_id = users.id
+        JOIN profiles ON users.id = profiles.user_id
+      WHERE
+        salaries.current_salary = true
+      GROUP BY
+        1
+      ORDER BY
+        1
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  def salaries_by_years_of_experience
+    sql = <<-SQL
+      SELECT
+        CAST(EXTRACT(YEAR FROM salaries.start_date) AS INTEGER) - profiles.graduation_year AS years_of_xp,
+        COUNT(salaries.id) AS submission_count,
+        CAST(AVG(salaries.amount) AS INTEGER) AS average_salary,
+        MIN(salaries.amount) AS minimum_salary,
+        MAX(salaries.amount) AS maximum_salary
+      FROM
+        salaries
+        JOIN users ON salaries.user_id = users.id
+        JOIN profiles ON users.id = profiles.user_id
+      GROUP BY
+        1
+      ORDER BY
+        1 DESC
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/app/services/salary_reporting_service.rb
+++ b/app/services/salary_reporting_service.rb
@@ -15,9 +15,9 @@ class SalaryReportingService
       WHERE
         salaries.current_salary = true
       GROUP BY
-        1
+        graduation_year
       ORDER BY
-        1
+        graduation_year
     SQL
 
     ActiveRecord::Base.connection.execute(sql)
@@ -26,7 +26,7 @@ class SalaryReportingService
   def salaries_by_years_of_experience
     sql = <<-SQL
       SELECT
-        CAST(EXTRACT(YEAR FROM salaries.start_date) AS INTEGER) - profiles.graduation_year AS years_of_xp,
+        CAST(EXTRACT(YEAR FROM salaries.start_date) AS INTEGER) - profiles.graduation_year AS years_of_experience,
         COUNT(salaries.id) AS submission_count,
         CAST(AVG(salaries.amount) AS INTEGER) AS average_salary,
         MIN(salaries.amount) AS minimum_salary,
@@ -36,9 +36,9 @@ class SalaryReportingService
         JOIN users ON salaries.user_id = users.id
         JOIN profiles ON users.id = profiles.user_id
       GROUP BY
-        1
+        years_of_experience 
       ORDER BY
-        1 DESC
+        years_of_experience DESC
     SQL
 
     ActiveRecord::Base.connection.execute(sql)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :user do
     # We never store the actual slack id in our database, only a hashed version.
     # It is impossible to back into the slack id given the hashed id.
-    slack_id { Digest::SHA256.hexdigest("12345ABCDEF") }
+    sequence(:slack_id) { |i| Digest::SHA256.hexdigest("#{1000 + i}ABCDEF") }
   end
 end

--- a/spec/services/salary_reporting_service_spec.rb
+++ b/spec/services/salary_reporting_service_spec.rb
@@ -58,7 +58,7 @@ describe SalaryReportingService do
     let(:result) { service.salaries_by_years_of_experience }
     let(:expected1) do
       {
-        "years_of_xp" => 1,
+        "years_of_experience" => 1,
         "submission_count" => 1,
         "average_salary" => 95000,
         "minimum_salary" => 95000,
@@ -68,7 +68,7 @@ describe SalaryReportingService do
 
     let(:expected2) do
       {
-        "years_of_xp" => 0,
+        "years_of_experience" => 0,
         "submission_count" => 2,
         "average_salary" => 80000,
         "minimum_salary" => 75000,

--- a/spec/services/salary_reporting_service_spec.rb
+++ b/spec/services/salary_reporting_service_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+describe SalaryReportingService do
+  subject(:service) { described_class.new }
+
+  describe "#current_salary_by_graduation_year" do
+    before do
+      user_2017_1 = create(:user, profile: create(:profile, graduation_year: 2017))
+      user_2017_2 = create(:user, profile: create(:profile, graduation_year: 2017))
+      user_2018 = create(:user, profile: create(:profile, graduation_year: 2018))
+
+      create(:salary, :remote, user: user_2017_1, start_date: "2017-03-20", end_date: "2018-06-01", amount: 75000)
+      create(:salary, :remote, user: user_2017_1, start_date: "2018-06-20", end_date: nil, current_salary: true, amount: 95000)
+
+      create(:salary, :remote, user: user_2017_2, start_date: "2018-06-20", end_date: nil, current_salary: true, amount: 105000)
+
+      create(:salary, :remote, user: user_2018, start_date: "2018-03-20", end_date: nil, current_salary: true, amount: 85000)
+    end
+    let(:result) { service.current_salary_by_graduation_year }
+    let(:expected1) do
+      {
+        "graduation_year" => 2017,
+        "submission_count" => 2,
+        "average_salary" => 100000,
+        "minimum_salary" => 95000,
+        "maximum_salary" => 105000
+      }
+    end
+
+    let(:expected2) do
+      {
+        "graduation_year" => 2018,
+        "submission_count" => 1,
+        "average_salary" => 85000,
+        "minimum_salary" => 85000,
+        "maximum_salary" => 85000
+      }
+    end
+
+    it "returns salaries by years of experience" do
+      expect(result.count).to eq 2
+      expect(result.first).to eq expected1
+      expect(result[1]).to eq expected2
+    end
+  end
+
+  describe "#salaries_by_years_of_experience" do
+    before do
+      user_2017 = create(:user, profile: create(:profile, graduation_year: 2017))
+      user_2018 = create(:user, profile: create(:profile, graduation_year: 2018))
+
+      create(:salary, :remote, user: user_2017, start_date: "2017-03-20", end_date: "2018-06-01", amount: 75000)
+      create(:salary, :remote, user: user_2017, start_date: "2018-06-20", end_date: nil, current_salary: true, amount: 95000)
+
+      create(:salary, :remote, user: user_2018, start_date: "2018-03-20", end_date: nil, current_salary: true, amount: 85000)
+    end
+
+    let(:result) { service.salaries_by_years_of_experience }
+    let(:expected1) do
+      {
+        "years_of_xp" => 1,
+        "submission_count" => 1,
+        "average_salary" => 95000,
+        "minimum_salary" => 95000,
+        "maximum_salary" => 95000
+      }
+    end
+
+    let(:expected2) do
+      {
+        "years_of_xp" => 0,
+        "submission_count" => 2,
+        "average_salary" => 80000,
+        "minimum_salary" => 75000,
+        "maximum_salary" => 85000
+      }
+    end
+
+    it "returns salaries by years of experience" do
+      expect(result.count).to eq 2
+      expect(result.first).to eq expected1
+      expect(result[1]).to eq expected2
+    end
+  end
+end


### PR DESCRIPTION
#  Issue Link
[#16](https://github.com/jesse-spevack/salaries/issues/16)

# Background

PR adds sql queries that will show salary average, min, and max by:
1. Graduation year
 - Here we only use current salaries because someone's first salary should not affect their graduation cohort's average salary if it is not that person's current salary. In other words my first salary is not my current salary and should therefore have no impact on the average salary of a 2017 grad.
2. Years of experience
- Here we define years of experience as whole years between graduation and salary start date. So everyone is assumed to have graduated on January 1st, which makes things much simpler. Also folks seemed hesitant to put their cohort in to the spreadsheet. We might consider doing like a graduation quarter, but that might be confusing. Over time, months of experience become less significant so using whole years I think is fine.
- A person who graduates in 2019 with a salary start date of March 3, 2019, will be considered to have 0 years of experience for that particular salary. However, the same person with another salary with start date of January 1, 2020 will be considered to have 1 year of experience for this newer salary.
- This same person's first salary will count in the average / min / max query for people with 0 years of experience. And the second salary will count in the average / min / max query for people with 1 year of experience. In this way all inputted salaries will be useful, not just the latest.